### PR TITLE
Added ability to pass router middleware callback in replacement of options object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 /lib
 /dist
 /docs
+.access.log
+.error.log

--- a/src/modules/Router.js
+++ b/src/modules/Router.js
@@ -51,6 +51,9 @@ export default class Router {
      *@param {routeOptions} [options] - optional configuration options
     */
     set(method, url, callback, options) {
+        if (Util.isCallable(options))
+            options = {middleware: options};
+
         this.routes[method].push([url, callback, options || null]);
     }
 

--- a/test/unit/modules/Router.spec.js
+++ b/test/unit/modules/Router.spec.js
@@ -42,6 +42,16 @@ describe('Router', function() {
                 return route[0] === '/' && route[1] === callback && route[2] === options;
             });
         });
+
+        it(`should resolve options to an object with the middleware key set to the given middleware callback
+        if options argument is a callable`, function() {
+            const callback = function() {}, options = () => {};
+            router.options('/', callback, options);
+            expect(router.routes.options).to.be.lengthOf(1).and.to.satisfy(function(routes) {
+                let route = routes[0];
+                return route[0] === '/' && route[1] === callback && route[2].middleware === options;
+            });
+        });
     });
 
     describe('#head(url, callback, options?)', function() {


### PR DESCRIPTION
This pull request adds the ability to pass a middleware callback method into the router api methods in the place of the options object.

## Usage Examples
```javascript
import RServer from 'r-server';
import {admin} from './middleware/UserMiddleware';

const app = RServer.instance();

app.get('/users', (req, res) => {
}, admin);
```

This makes it easier unlike setting the middleware in an object even when there are no more routing options to pass along like shown below

```javascript
app.post('/users', (req, res) => {
}, {middleware: admin})
```