### PR TITLE
Added ability to set routing url base path

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ RServer is a fully integrated [node.js](https://nodejs.org/en/docs/guides/anatom
 
 Despite being configurable for advanced usage, it requires no configurations to get started. It is fully compatible with [express.js](https://expressjs.com/) and provides even more functionalities out of the box.
 
+## Newly Added Features
+
+- Ability to set route base path that will be prepended to all route urls. [here](#route-base-path)
+- Https integration and setup made easy [here](#https-support)
+- Support for [byte-range](#range-request-support) requests
+
 ## Getting Started (NPM install)
 
 ```bash
@@ -60,6 +66,8 @@ R-Server gives you many excellent features out of the box, saving you the stress
 
 9. [HTTPS Support](#https-support)
 
+10. [Range Request Support](#range-request-support)
+
 ### Request Body Parser
 
 It comes with an inbuilt request body parser, that supports all forms of http request data such as **urlencoded query strings**, **application/json data**, **application/x-www-form-urlencoded data** and **multipart/form-data** formats. Parsed fields and files are made available on the request object through the `query`, `body`, `data` and `files` property. Uploaded files are stored in a tmp folder, **storage/tmp** folder by default unless otherwise stated in a config file.
@@ -96,6 +104,10 @@ It provides an excellent routing engine, with parameter capturing and can incorp
 Unlike in [express.js](https://expressjs.com/), parameter capturing sections are enclosed in curly braces `{}` and you are not prevented from using hyphen in your parameter names.
 
 It also supports chained routes through the `Router#route(url)` method. The callback method can be asynchronous or can return promises.
+
+It also allows you to set route base path that gets prepended to all route urls and middleware urls.
+
+**Note that route urls can only be string patterns, and not regex objects**.
 
 **Usage Example**:
 
@@ -170,6 +182,24 @@ app.route('users/{int:userId}')
     .delete((req, res, userId) => {
         //delete user profile
     });
+```
+
+### Route Base Path
+
+It provides api for setting routing base path that gets prepended to all route urls and middleware urls. This is very helpful when exposing versioned api endpoints in your applications.
+
+```javascript
+app.setBasePath(basePath);
+
+//examples
+app.setBasePath('api/v2.0');
+
+//this route will be called when request is made on the endpoint /api/v2.0/auth
+app.post('auth', (req, res)=> {
+    res.end('received');
+}));
+
+app.listen(null, () => console.log('listening'));
 ```
 
 ### Static File Server
@@ -478,6 +508,10 @@ export default {
     }
 };
 ```
+
+### Range Request Support
+
+RServer will automatically detect and handle any [byte-range](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests) requests that hits the server. This is very important as it eases the server load when serving large files as browsers tend to throttle requests using range request mechanisms. The link above is a great place to read more on range requests.
 
 ## Contributing
 

--- a/src/modules/App.js
+++ b/src/modules/App.js
@@ -48,6 +48,14 @@ export default class App {
     }
 
     /**
+     * sets routing base path that gets prepended to all route and middleware urls
+     *@param {string} basePath - routing base path
+    */
+    setBasePath(basePath) {
+        this.server.router.setBasePath(basePath);
+    }
+
+    /**
      * performs route rules for http OPTIONS method verb
      *@param {string} url - the route url
      *@param {Function} callback - callback function

--- a/src/modules/Server.js
+++ b/src/modules/Server.js
@@ -172,9 +172,9 @@ export default class {
     */
     mount(baseUrl, router) {
         //baseUrl = baseUrl.replace(/\/+$/, '');
-        const resolve = ([url, callback, options]) => {
+        const resolve = function([url, callback, options]) {
             return [
-                path.join(baseUrl, url),
+                this.router.resolvePath(baseUrl, url),
                 callback,
                 options
             ];
@@ -185,10 +185,10 @@ export default class {
 
         //resolve all routes, each apiRoutes is of the form [url, callback, options]
         for (const [api, apiRoutes] of Object.entries(router.routes))
-            router.routes[api] = apiRoutes.map(resolve);
+            router.routes[api] = apiRoutes.map(resolve, this);
 
         //resolve all middlewares. each middleware is of the format [url, callback, options]
-        router.middlewares = router.middlewares.map(resolve);
+        router.middlewares = router.middlewares.map(resolve, this);
 
         this.mountedRouters.push(router);
     }

--- a/test/unit/modules/App.spec.js
+++ b/test/unit/modules/App.spec.js
@@ -189,4 +189,45 @@ describe('App', function() {
             });
         });
     });
+
+    describe('#setBasePath(basePath)', function() {
+        it(`should set the app routing and middleware base path, that gets pretended to all
+            application routes, including mounted routes`, function() {
+            const authRoutes = new Router();
+
+            app.setBasePath('api/v1.0');
+
+            const callback = () => {};
+
+            authRoutes.post('/', callback);
+            authRoutes.use('/', callback);
+
+            app.use('/', callback);
+            app.get('/', callback);
+
+            app.mount('auth', authRoutes);
+
+            expect(app.server.router.routes.get[0]).to.deep.equals([
+                'api/v1.0/',
+                callback,
+                null
+            ]);
+            expect(app.server.mountedRouters[0].routes.post[0]).to.deep.equals([
+                'api/v1.0/auth/',
+                callback,
+                null
+            ]);
+
+            expect(app.server.router.middlewares[0]).to.deep.equals([
+                'api/v1.0/',
+                [callback],
+                null
+            ]);
+            expect(app.server.mountedRouters[0].middlewares[0]).to.deep.equals([
+                'api/v1.0/auth/',
+                [callback],
+                null
+            ]);
+        });
+    });
 });

--- a/test/unit/modules/Engine.spec.js
+++ b/test/unit/modules/Engine.spec.js
@@ -157,15 +157,15 @@ describe('Engine', function() {
             expect(engine.matchUrl('/')).to.be.true;
 
             //create an engine with request url of 'users/1/profile'
-            engine = new Engine('users/1/profile', 'GET', request, response, logger);
+            engine = new Engine('api/v1.0/users/1/profile', 'GET', request, response, logger);
 
-            expect(engine.matchUrl('users/{int:user-id}/profile')).to.be.true;
-            expect(engine.matchUrl('users/{int:user-id}/[profile]+')).to.be.true;
-            expect(engine.matchUrl('/users/{int:user-id}/(profile)?')).to.be.true;
+            expect(engine.matchUrl('api/v1.0/users/{int:user-id}/profile')).to.be.true;
+            expect(engine.matchUrl('api/v1.0/users/{int:user-id}/[profile]+')).to.be.true;
+            expect(engine.matchUrl('api/v1.0/users/{int:user-id}/(profile)?')).to.be.true;
             expect(engine.matchUrl('*')).to.be.true;
-            expect(engine.matchUrl('users/*')).to.be.true;
-            expect(engine.matchUrl('users/[0-9]+/{view}?')).to.be.true;
-            expect(engine.matchUrl('users/[0-9]+/profile/{optional}?')).to.be.true;
+            expect(engine.matchUrl('api/v1.0/users/*')).to.be.true;
+            expect(engine.matchUrl('api/v1.0/users/[0-9]+/{view}?')).to.be.true;
+            expect(engine.matchUrl('api/v1.0/users/[0-9]+/profile/{optional}?')).to.be.true;
         });
 
         it(`should parse the route url, convert it to a regex pattern, match it with the request


### PR DESCRIPTION
This pull request provides **api** for setting routing base path that gets prepended to all route urls and middleware urls. This is very helpful when exposing versioned api endpoints in your applications.

```javascript
app.setBasePath(basePath);

//examples
app.setBasePath('api/v2.0');

//this route will be called when request is made on the endpoint /api/v2.0/auth
app.post('auth', (req, res)=> {
    res.end('received');
}));

app.listen(null, () => console.log('listening'));
```